### PR TITLE
add pocket mobile auth exchange

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,11 +11,13 @@ app.get('/hello', function(req, res) {
 var UserController = require('./user/UserController');
 app.use('/api/users', UserController);
 
-
 var AuthController = require('./auth/AuthController');
 app.use('/api/auth', AuthController);
 
+var MobileController = require('./auth/MobileController');
+app.use('/api/auth/mobile', MobileController);
+
 var CommandController = require('./command/CommandController');
 app.use('/command', CommandController);
- 
+
 module.exports = app;

--- a/auth/MobileController.js
+++ b/auth/MobileController.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const express = require('express');
+const router = express.Router();
+const rp = require('request-promise');
+const scoutuser = require('../scout_user');
+const url = require('url');
+
+var pocketConsumerKey, userAuthKey;
+
+const oathRequestOptions = {
+  uri: 'https://getpocket.com/v3/oauth/request',
+  method: 'POST',
+  body: '',
+  headers: {
+    'Content-Type': 'application/json; charset=UTF-8',
+    'X-Accept': 'application/json'
+  }
+};
+
+const finalAuthorizeOptions = {
+  uri: 'https://getpocket.com/v3/oauth/authorize',
+  method: 'POST',
+  body: '',
+  headers: {
+    'Content-Type': 'application/json; charset=UTF-8',
+    'X-Accept': 'application/json'
+  }
+};
+
+// Read the configuration file for pocket info.
+pocketConsumerKey = process.env.POCKET_KEY;
+
+//
+// Pocket Auth Flows
+//
+router.get('/login', function(req, res) {
+  const requrl = url.format({
+    protocol: req.protocol,
+    host: req.get('host')
+  });
+  const redirUri = `${requrl}/api/auth/mobile/redirecturi`;
+  console.log(`redirUri = ${redirUri}`);
+
+  var oauthBody = {
+    consumer_key: pocketConsumerKey,
+    redirect_uri: redirUri
+  };
+  oathRequestOptions.body = JSON.stringify(oauthBody);
+  rp(oathRequestOptions).then(function(body) {
+    let jsonBody = JSON.parse(body);
+    userAuthKey = jsonBody.code;
+
+    var redir =
+      `https://getpocket.com/auth/authorize` +
+      `?request_token=${userAuthKey}&redirect_uri=${redirUri}`;
+    return res.redirect(redir);
+  });
+});
+
+router.get('/redirecturi', function(req, res) {
+  var authBody = {
+    consumer_key: pocketConsumerKey,
+    code: userAuthKey
+  };
+  finalAuthorizeOptions.body = JSON.stringify(authBody);
+  console.log('calling redirect');
+
+  rp(finalAuthorizeOptions)
+    .then(function(body) {
+      let jsonBody = JSON.parse(body);
+      const pocketUserAccessToken = jsonBody.access_token;
+      const pockerUserId = jsonBody.username;
+
+      // Save to the config to scoutuser data
+      console.log(`Authorized: ${pockerUserId}/${pocketUserAccessToken}`);
+      processScoutUser(pockerUserId, pocketUserAccessToken);
+    })
+    .catch(function(err) {
+      console.log('Call failed' + err);
+    });
+  res.status(200).send('OK');
+});
+
+async function processScoutUser(userid, access_token) {
+  try {
+    let existingScoutuser = await scoutuser.findOne({ userid });
+    if (existingScoutuser) {
+      console.log('Updating existing Scoutuser');
+      existingScoutuser.access_token = access_token;
+      await existingScoutuser.save();
+    } else {
+      console.log(`Creating new Scoutuser`);
+      let newScoutuser = await scoutuser.create({
+        userid,
+        access_token
+      });
+      console.log(`Created ScoutUser in DB: ${newScoutuser}`);
+    }
+  } catch (err) {
+    console.log(`Scoutuser operation failed: ${err}`);
+  }
+}
+
+module.exports = router;

--- a/package-lock.json
+++ b/package-lock.json
@@ -586,10 +586,24 @@
         "xmlbuilder": "4.2.1"
       },
       "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        },
         "sax": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
           "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+        },
+        "url": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          }
         },
         "uuid": {
           "version": "3.1.0",
@@ -9688,9 +9702,9 @@
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
     },
     "url": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "nyc": "^11.6.0",
     "readability-js": "^1.0.7",
     "request-promise": "^4.2.2",
-    "serve-favicon": "~2.4.5"
+    "serve-favicon": "~2.4.5",
+    "url": "^0.11.0"
   },
   "devDependencies": {
     "eslint-config-google": "^0.9.1"

--- a/scout_user.js
+++ b/scout_user.js
@@ -5,10 +5,8 @@ var ScoutUserSchema = new mongoose.Schema(
   {
     userid: {
       type: String,
-      lowercase: true,
       unique: true,
       required: [true, `can't be blank`],
-      match: [/\S+@\S+\.\S+/, 'is invalid'],
       index: true
     },
     access_token: String


### PR DESCRIPTION
Fixes #19 
Fixes #24 

Import mobile authentication flow from scout-pocketauth repo:

* add new controller using route '/api/auth/mobile'
* tested flow both with localhost and Heroku deployment to verify the redirect URI is getting set properly
* tested new user creation & update of existing user 
* removed the format constraints on scoutuser.userid (this is issue #24 but was required to complete testing with my Pocket user)

This branch is currently deployed at: http://scout-ua.herokuapp.com/
