### PR TITLE
handle pocket response status==2

### DIFF
--- a/command/CommandController.js
+++ b/command/CommandController.js
@@ -223,7 +223,7 @@ function scoutTitles(getBody, res) {
   rp(getOptions)
     .then(function(body) {
       const jsonBody = JSON.parse(body);
-      if (jsonBody.status == '1') {
+      if (jsonBody.status === 1 || jsonBody.status === 2) {
         console.log(jsonBody);
         let articles = [];
 
@@ -267,6 +267,12 @@ function scoutTitles(getBody, res) {
         });
 
         res.status(200).send(JSON.stringify({ articles }));
+      } else {
+        res.status(500).send(
+          JSON.stringify({
+            error: `Unknown status from Pocket: ${jsonBody.status}`
+          })
+        );
       }
     })
     .catch(function(err) {


### PR DESCRIPTION
Fixes #67 
This change assumes that status=2 is just an indicator that there are no saved articles in the account and that the rest of the response is structured as we expect it to be. 

This has been successfully tested against an account that has no articles. The timeout is eliminated and the ScoutTitles command returns an empty articles array.