### PR TITLE
Add intro and outro fields to API

### DIFF
--- a/command/AudioFileHelper.js
+++ b/command/AudioFileHelper.js
@@ -14,9 +14,17 @@ class CommandHelper {
       summaryOnly ? 'summary' : 'full'
     );
 
-    // then see if that file still exists at s3
+    if (!await this.checkFileExistence(fileUrl)) {
+      fileUrl = '';
+    }
+
+    return fileUrl;
+  }
+
+  async checkFileExistence(fileUrl) {
+    // checks if that file still exists at s3
     if (fileUrl) {
-      logger.info(`Checking location for item=${articleId}: ${fileUrl}`);
+      logger.info(`Checking location for: ${fileUrl}`);
       const path = url.parse(fileUrl).path;
       const params = {
         Bucket: process.env.POLLY_S3_BUCKET,
@@ -27,13 +35,13 @@ class CommandHelper {
         const s3request = s3.headObject(params);
         await s3request.promise();
         logger.debug('Verified existing file');
+        return true;
       } catch (err) {
         logger.warn('File no longer exists');
-        fileUrl = '';
+        return false;
       }
     }
-
-    return fileUrl;
+    return false;
   }
 
   async storeAudioFileLocation(articleId, summaryOnly, location) {

--- a/command/AudioFileHelper.js
+++ b/command/AudioFileHelper.js
@@ -51,6 +51,29 @@ class CommandHelper {
       location
     );
   }
+
+  async getMetaAudioLocation(articleId) {
+    let result = await database.getMetaAudioLocation(articleId);
+
+    if (result) {
+      if (
+        (await this.checkFileExistence(result.intro_location)) &&
+        (await this.checkFileExistence(result.outro_location))
+      ) {
+        return result;
+      }
+    }
+
+    return '';
+  }
+
+  async storeMetaAudioLocation(articleId, introLocation, outroLocation) {
+    return await database.storeMetaAudioLocation(
+      articleId,
+      introLocation,
+      outroLocation
+    );
+  }
 }
 
 module.exports = CommandHelper;

--- a/command/AudioFileHelper.js
+++ b/command/AudioFileHelper.js
@@ -53,26 +53,19 @@ class CommandHelper {
   }
 
   async getMetaAudioLocation(articleId) {
-    let result = await database.getMetaAudioLocation(articleId);
-
-    if (result) {
-      if (
-        (await this.checkFileExistence(result.intro_location)) &&
-        (await this.checkFileExistence(result.outro_location))
-      ) {
-        return result;
-      }
-    }
-
-    return '';
+    return await database.getMetaAudioLocation(articleId);
   }
 
-  async storeMetaAudioLocation(articleId, introLocation, outroLocation) {
-    return await database.storeMetaAudioLocation(
+  async storeIntroLocation(articleId, introLocation, summaryOnly) {
+    return await database.storeIntroLocation(
       articleId,
       introLocation,
-      outroLocation
+      summaryOnly
     );
+  }
+
+  async storeOutroLocation(articleId, outroLocation) {
+    return await database.storeOutroLocation(articleId, outroLocation);
   }
 }
 

--- a/command/CommandController.js
+++ b/command/CommandController.js
@@ -276,8 +276,8 @@ async function processArticleRequest(
 
 async function generateMetaAudio(data) {
   let metaAudio = await audioHelper.getMetaAudioLocation(data.item_id);
-  let intro = metaAudio.intro_location;
-  let outro = metaAudio.outro_location;
+  let intro;
+  let outro;
   let voice = process.env.META_VOICE || process.env.POLLY_VOICE || 'Salli';
 
   if (!metaAudio) {
@@ -303,6 +303,9 @@ async function generateMetaAudio(data) {
     outro = await buildAudioFromText(`${authorString}${dateString}`, voice);
 
     await audioHelper.storeMetaAudioLocation(data.item_id, intro, outro);
+  } else {
+    intro = metaAudio.intro_location;
+    outro = metaAudio.outro_location;
   }
 
   // regenerate end_instructions if file doesn't exist anymore

--- a/command/CommandController.js
+++ b/command/CommandController.js
@@ -275,17 +275,16 @@ async function processArticleRequest(
 }
 
 async function generateMetaAudio(data) {
-  let intro;
-  let outro;
+  let metaAudio = await audioHelper.getMetaAudioLocation(data.item_id);
+  let intro = metaAudio.intro_location;
+  let outro = metaAudio.outro_location;
   let voice = process.env.META_VOICE || process.env.POLLY_VOICE || 'Salli';
 
-  if (!intro) {
+  if (!metaAudio) {
     logger.info('Generating intro for item:' + data.item_id);
     let publisherText = data.publisher ? `From ${data.publisher}, ` : ``;
     intro = await buildAudioFromText(`${publisherText}${data.title}`, voice);
-  }
 
-  if (!outro) {
     logger.info('Generating outro for item:' + data.item_id);
     articleOptions.formData = {
       consumer_key: process.env.POCKET_KEY,
@@ -302,6 +301,8 @@ async function generateMetaAudio(data) {
       'Published on ' + publishedDate.toLocaleDateString('en-US', dateOptions);
     let authorString = data.author ? `Written by ${data.author}. ` : '';
     outro = await buildAudioFromText(`${authorString}${dateString}`, voice);
+
+    await audioHelper.storeMetaAudioLocation(data.item_id, intro, outro);
   }
 
   // regenerate end_instructions if file doesn't exist anymore

--- a/command/texttools.js
+++ b/command/texttools.js
@@ -49,10 +49,7 @@ const texttools = {
   },
 
   buildSummaryText: function(title, content) {
-    return `Here is a summary of: ${title.replace(
-      '\\',
-      ''
-    )}.  ${content.replace('\\', '')}`;
+    return content.replace('\\', '');
   }
 };
 

--- a/data/database.js
+++ b/data/database.js
@@ -114,15 +114,32 @@ class Database {
     return await MetaAudioLocation.get({ item_id: articleId });
   }
 
-  async storeMetaAudioLocation(articleId, introLocation, outroLocation) {
-    logger.info(`storeMetaAudioLocation for ${articleId}`);
+  async storeIntroLocation(articleId, introLocation, summaryOnly) {
+    logger.info(`storeIntroLocation for ${articleId}`);
     let metaLocation = await MetaAudioLocation.get({ item_id: articleId });
     if (!metaLocation) {
       metaLocation = new MetaAudioLocation({
         item_id: articleId
       });
     }
-    metaLocation.intro_location = introLocation;
+    if (summaryOnly) {
+      metaLocation.intro_summary_location = introLocation;
+    } else {
+      metaLocation.intro_full_location = introLocation;
+    }
+
+    metaLocation.date = Date.now();
+    await metaLocation.save();
+  }
+
+  async storeOutroLocation(articleId, outroLocation) {
+    logger.info(`storeOutroLocation for ${articleId}`);
+    let metaLocation = await MetaAudioLocation.get({ item_id: articleId });
+    if (!metaLocation) {
+      metaLocation = new MetaAudioLocation({
+        item_id: articleId
+      });
+    }
     metaLocation.outro_location = outroLocation;
     metaLocation.date = Date.now();
     await metaLocation.save();

--- a/data/database.js
+++ b/data/database.js
@@ -1,5 +1,6 @@
 const ScoutUser = require('./models/ScoutUser');
 const AudioFileLocation = require('./models/AudioFileLocation');
+const MetaAudioLocation = require('./models/MetaAudioLocation');
 const Hostname = require('./models/Hostname');
 const logger = require('../logger');
 
@@ -106,6 +107,25 @@ class Database {
 
     await data.save();
     return data;
+  }
+
+  async getMetaAudioLocation(articleId) {
+    logger.info(`getMetaAudioLocation for ${articleId}`);
+    return await MetaAudioLocation.get({ item_id: articleId });
+  }
+
+  async storeMetaAudioLocation(articleId, introLocation, outroLocation) {
+    logger.info(`storeMetaAudioLocation for ${articleId}`);
+    let metaLocation = await MetaAudioLocation.get({ item_id: articleId });
+    if (!metaLocation) {
+      metaLocation = new MetaAudioLocation({
+        item_id: articleId
+      });
+    }
+    metaLocation.intro_location = introLocation;
+    metaLocation.outro_location = outroLocation;
+    metaLocation.date = Date.now();
+    await metaLocation.save();
   }
 }
 

--- a/data/models/MetaAudioLocation.js
+++ b/data/models/MetaAudioLocation.js
@@ -1,0 +1,20 @@
+const dynamoose = require('dynamoose');
+
+const schema = new dynamoose.Schema({
+  /* The item_id acts as the primary key for this table and is intended to be
+   * set to the article's item_id value supplied by Pocket in the titles list.
+   * This ID appears to be specific to an article and is shared across
+   * Pocket's users, so we can serve the same file to multiple Scout users.
+   */
+  item_id: {
+    type: String,
+    hashKey: true
+  },
+  intro_location: String,
+  outro_location: String,
+  date: Date
+});
+
+const MetaAudioLocation = dynamoose.model('MetaAudioLocation', schema);
+
+module.exports = MetaAudioLocation;

--- a/data/models/MetaAudioLocation.js
+++ b/data/models/MetaAudioLocation.js
@@ -10,7 +10,8 @@ const schema = new dynamoose.Schema({
     type: String,
     hashKey: true
   },
-  intro_location: String,
+  intro_full_location: String,
+  intro_summary_location: String,
   outro_location: String,
   date: Date
 });

--- a/postman-api.json
+++ b/postman-api.json
@@ -282,12 +282,6 @@
                   "value": "1",
                   "description": "",
                   "type": "text"
-                },
-                {
-                  "key": "end_instructions",
-                  "value": "1",
-                  "description": "",
-                  "type": "text"
                 }
               ]
             },
@@ -297,7 +291,7 @@
               "path": ["command", "intent"]
             },
             "description":
-              "Searches the user's saved Pocket articles for one with an article title that matches the `searchTerms`. \n\nIf found, returns the location of an audio file which contains a spoken version of the article.\n\nIncluding the optional parameter `extended_data` with a value of `1` will also attempt to fetch the publisher of the article (e.g. \"The New Yorker\" instead of \"newyorker.com\") and the URL of the site's favicon. Note that these are not available in all circumstances so test for validity.\n\nIncluding the optional parameter `end_instructions` with a value of `1` will also return an URL to an audio file of instructions to give to the user at the end of an article (for the Alexa Skill).\n\nSample return values:\n\nSuccess:\n```\n{\n    \"item_id\": \"1159711105\",\n    \"sort_id\": 0,\n    \"resolved_url\": \"https://www.newyorker.com/books/page-turner/my-last-day-as-a-surgeon\",\n    \"title\": \"My Last Day as a Surgeon\",\n    \"author\": \"Paul Kalanithi\",\n    \"lengthMinutes\": 9,\n    \"imageURL\": \"https://media.newyorker.com/photos/5909736debe912338a377603/16:9/w_1200,h_630,c_limit/Kalanithi-excerpt-2.jpg\",\n    \"url\": \"https://scout-audio.s3.amazonaws.com/5e82cf95-a6f9-4d41-bf7d-669e66e34974.mp3\",\n    \"instructions_url\": \"https://scout-streaming-2018.s3.amazonaws.com/94c38b5d-7099-4eb7-aa0e-cc5e76ee2f58.mp3\",\n    \"offset_ms\": 1000\n}```\n\nFailure:\n```\n{\n    \"speech\": \"Unable to find a matching article. Try another phrase.\"\n}\n```"
+              "Searches the user's saved Pocket articles for one with an article title that matches the `searchTerms`. \n\nIf found, returns the location of an audio file which contains a spoken version of the article.\n\nIncluding the optional parameter `extended_data` with a value of `1` will also attempt to fetch the publisher of the article (e.g. \"The New Yorker\" instead of \"newyorker.com\") and the URL of the site's favicon. Note that these are not available in all circumstances so test for validity.\n\nSample return values:\n\nSuccess:\n```\n{\n    \"item_id\": \"1159711105\",\n    \"sort_id\": 0,\n    \"resolved_url\": \"https://www.newyorker.com/books/page-turner/my-last-day-as-a-surgeon\",\n    \"title\": \"My Last Day as a Surgeon\",\n    \"author\": \"Paul Kalanithi\",\n    \"lengthMinutes\": 9,\n    \"imageURL\": \"https://media.newyorker.com/photos/5909736debe912338a377603/16:9/w_1200,h_630,c_limit/Kalanithi-excerpt-2.jpg\",\n    \"url\": \"https://scout-audio.s3.amazonaws.com/5e82cf95-a6f9-4d41-bf7d-669e66e34974.mp3\",\n    \"offset_ms\": 1000\n}```\n\nFailure:\n```\n{\n    \"speech\": \"Unable to find a matching article. Try another phrase.\"\n}\n```"
           },
           "response": []
         },
@@ -337,12 +331,6 @@
                   "key": "extended_data",
                   "value": "1",
                   "type": "text"
-                },
-                {
-                  "key": "end_instructions",
-                  "value": "1",
-                  "description": "",
-                  "type": "text"
                 }
               ]
             },
@@ -352,7 +340,7 @@
               "path": ["command", "intent"]
             },
             "description":
-              "Searches the user's saved Pocket articles for one with an article title that matches the `searchTerms`. \n\nIf found, returns the location of an audio file which contains an abridged version of the content at `url`.\n\nIncluding the optional parameter `extended_data` with a value of `1` will also attempt to fetch the publisher of the article (e.g. \"The New Yorker\" instead of \"newyorker.com\") and the URL of the site's favicon. Note that these are not available in all circumstances so test for validity.\n\nIncluding the optional parameter `end_instructions` with a value of `1` will also return an URL to an audio file of instructions to give to the user at the end of an article (for the Alexa Skill).\n\nSample return values:\n\nSuccess:\n```\n{\n    \"item_id\": \"1159711105\",\n    \"sort_id\": 0,\n    \"resolved_url\": \"https://www.newyorker.com/books/page-turner/my-last-day-as-a-surgeon\",\n    \"title\": \"My Last Day as a Surgeon\",\n    \"author\": \"Paul Kalanithi\",\n    \"lengthMinutes\": 9,\n    \"imageURL\": \"https://media.newyorker.com/photos/5909736debe912338a377603/16:9/w_1200,h_630,c_limit/Kalanithi-excerpt-2.jpg\",\n    \"url\": \"https://scout-audio.s3.amazonaws.com/5e82cf95-a6f9-4d41-bf7d-669e66e34974.mp3\",\n    \"instructions_url\": \"https://scout-streaming-2018.s3.amazonaws.com/94c38b5d-7099-4eb7-aa0e-cc5e76ee2f58.mp3\",\n    \"offset_ms\": 0\n}```\n\nFailure:\n```\n{\n    \"speech\": \"Unable to find a matching article. Try another phrase.\"\n}\n```"
+              "Searches the user's saved Pocket articles for one with an article title that matches the `searchTerms`. \n\nIf found, returns the location of an audio file which contains an abridged version of the content at `url`.\n\nIncluding the optional parameter `extended_data` with a value of `1` will also attempt to fetch the publisher of the article (e.g. \"The New Yorker\" instead of \"newyorker.com\") and the URL of the site's favicon. Note that these are not available in all circumstances so test for validity.\n\nSample return values:\n\nSuccess:\n```\n{\n    \"item_id\": \"1159711105\",\n    \"sort_id\": 0,\n    \"resolved_url\": \"https://www.newyorker.com/books/page-turner/my-last-day-as-a-surgeon\",\n    \"title\": \"My Last Day as a Surgeon\",\n    \"author\": \"Paul Kalanithi\",\n    \"lengthMinutes\": 9,\n    \"imageURL\": \"https://media.newyorker.com/photos/5909736debe912338a377603/16:9/w_1200,h_630,c_limit/Kalanithi-excerpt-2.jpg\",\n    \"url\": \"https://scout-audio.s3.amazonaws.com/5e82cf95-a6f9-4d41-bf7d-669e66e34974.mp3\",\n    \"offset_ms\": 0\n}```\n\nFailure:\n```\n{\n    \"speech\": \"Unable to find a matching article. Try another phrase.\"\n}\n```"
           },
           "response": []
         },
@@ -472,7 +460,7 @@
                   "type": "text"
                 },
                 {
-                  "key": "end_instructions",
+                  "key": "meta_audio",
                   "value": "1",
                   "description": "",
                   "type": "text"
@@ -485,7 +473,7 @@
               "path": ["command", "article"]
             },
             "description":
-              "Returns the location of an audio file which contains a spoken version of the content at `url`.\n\nIf the article at `url` is also present in the user's Pocket account, additional metadata will be provided to describe the content.\n\nIncluding the optional parameter `extended_data` with a value of `1` will also attempt to fetch the publisher of the article (e.g. \"The New Yorker\" instead of \"newyorker.com\") and the URL of the site's favicon. Note that these are not available in all circumstances so test for validity.\n\nIncluding the optional parameter `end_instructions` with a value of `1` will also return an URL to an audio file of instructions to give to the user at the end of an article (for the Alexa Skill).\n\nSample return value:\n```\n{\n    \"item_id\": \"1159711105\",\n    \"sort_id\": 0,\n    \"resolved_url\": \"https://www.newyorker.com/books/page-turner/my-last-day-as-a-surgeon\",\n    \"title\": \"My Last Day as a Surgeon\",\n    \"author\": \"Paul Kalanithi\",\n    \"lengthMinutes\": 9,\n    \"imageURL\": \"https://media.newyorker.com/photos/5909736debe912338a377603/16:9/w_1200,h_630,c_limit/Kalanithi-excerpt-2.jpg\",\n    \"url\": \"https://scout-audio.s3.amazonaws.com/5e82cf95-a6f9-4d41-bf7d-669e66e34974.mp3\",\n    \"instructions_url\": \"https://scout-streaming-2018.s3.amazonaws.com/94c38b5d-7099-4eb7-aa0e-cc5e76ee2f58.mp3\",\n    \"offset_ms\": 1000\n}```"
+              "Returns the location of an audio file which contains a spoken version of the content at `url`.\n\nIf the article at `url` is also present in the user's Pocket account, additional metadata will be provided to describe the content.\n\nIncluding the optional parameter `extended_data` with a value of `1` will also attempt to fetch the publisher of the article (e.g. \"The New Yorker\" instead of \"newyorker.com\") and the URL of the site's favicon. Note that these are not available in all circumstances so test for validity.\n\nIncluding the optional parameter `meta_audio` with a value of `1` will also return URLs to audio files of intro, outro and instructions to give to the user before and after an article (for the Alexa Skill).\n\nSample return value:\n```\n{\n    \"item_id\": \"1159711105\",\n    \"sort_id\": 0,\n    \"resolved_url\": \"https://www.newyorker.com/books/page-turner/my-last-day-as-a-surgeon\",\n    \"title\": \"My Last Day as a Surgeon\",\n    \"author\": \"Paul Kalanithi\",\n    \"lengthMinutes\": 9,\n    \"imageURL\": \"https://media.newyorker.com/photos/5909736debe912338a377603/16:9/w_1200,h_630,c_limit/Kalanithi-excerpt-2.jpg\",\n    \"url\": \"https://scout-audio.s3.amazonaws.com/5e82cf95-a6f9-4d41-bf7d-669e66e34974.mp3\",\n    \"instructions_url\": \"https://scout-streaming-2018.s3.amazonaws.com/94c38b5d-7099-4eb7-aa0e-cc5e76ee2f58.mp3\",\n    \"intro_url\": \"https://scout-streaming-ben.s3.amazonaws.com/3efbb22f-c5cb-419c-8841-816dba15b7b8.mp3\",\n    \"outro_url\": \"https://scout-streaming-ben.s3.amazonaws.com/d0af2f31-1cbf-46cb-956c-1f995c05246b.mp3\",\n    \"offset_ms\": 1000\n}```"
           },
           "response": []
         },
@@ -522,7 +510,7 @@
                   "type": "text"
                 },
                 {
-                  "key": "end_instructions",
+                  "key": "meta_audio",
                   "value": "1",
                   "description": "",
                   "type": "text"
@@ -535,7 +523,7 @@
               "path": ["command", "summary"]
             },
             "description":
-              "Returns the location of an audio file which contains an abridged version of the content at `url`.\n\nIf the article at `url` is also present in the user's Pocket account, additional metadata will be provided to describe the content.\n\nIncluding the optional parameter `extended_data` with a value of `1` will also attempt to fetch the publisher of the article (e.g. \"The New Yorker\" instead of \"newyorker.com\") and the URL of the site's favicon. Note that these are not available in all circumstances so test for validity.\n\nIncluding the optional parameter `end_instructions` with a value of `1` will also return an URL to an audio file of instructions to give to the user at the end of an article (for the Alexa Skill).\n\nSample return value:\n```\n{\n    \"item_id\": \"1159711105\",\n    \"sort_id\": 0,\n    \"resolved_url\": \"https://www.newyorker.com/books/page-turner/my-last-day-as-a-surgeon\",\n    \"title\": \"My Last Day as a Surgeon\",\n    \"author\": \"Paul Kalanithi\",\n    \"lengthMinutes\": 9,\n    \"imageURL\": \"https://media.newyorker.com/photos/5909736debe912338a377603/16:9/w_1200,h_630,c_limit/Kalanithi-excerpt-2.jpg\",\n    \"url\": \"https://scout-audio.s3.amazonaws.com/5e82cf95-a6f9-4d41-bf7d-669e66e34974.mp3\",\n    \"instructions_url\": \"https://scout-streaming-2018.s3.amazonaws.com/94c38b5d-7099-4eb7-aa0e-cc5e76ee2f58.mp3\",\n    \"offset_ms\": 0\n}```"
+              "Returns the location of an audio file which contains an abridged version of the content at `url`.\n\nIf the article at `url` is also present in the user's Pocket account, additional metadata will be provided to describe the content.\n\nIncluding the optional parameter `extended_data` with a value of `1` will also attempt to fetch the publisher of the article (e.g. \"The New Yorker\" instead of \"newyorker.com\") and the URL of the site's favicon. Note that these are not available in all circumstances so test for validity.\n\nIncluding the optional parameter `meta_audio` with a value of `1` will also return URLs to audio files of intro, outro and instructions to give to the user before and after an article (for the Alexa Skill).\n\nSample return value:\n```\n{\n    \"item_id\": \"1159711105\",\n    \"sort_id\": 0,\n    \"resolved_url\": \"https://www.newyorker.com/books/page-turner/my-last-day-as-a-surgeon\",\n    \"title\": \"My Last Day as a Surgeon\",\n    \"author\": \"Paul Kalanithi\",\n    \"lengthMinutes\": 9,\n    \"imageURL\": \"https://media.newyorker.com/photos/5909736debe912338a377603/16:9/w_1200,h_630,c_limit/Kalanithi-excerpt-2.jpg\",\n    \"url\": \"https://scout-audio.s3.amazonaws.com/5e82cf95-a6f9-4d41-bf7d-669e66e34974.mp3\",\n    \"instructions_url\": \"https://scout-streaming-2018.s3.amazonaws.com/94c38b5d-7099-4eb7-aa0e-cc5e76ee2f58.mp3\",\n    \"intro_url\": \"https://scout-streaming-ben.s3.amazonaws.com/3efbb22f-c5cb-419c-8841-816dba15b7b8.mp3\",\n    \"outro_url\": \"https://scout-streaming-ben.s3.amazonaws.com/d0af2f31-1cbf-46cb-956c-1f995c05246b.mp3\",\n    \"offset_ms\": 0\n}```"
           },
           "response": []
         },

--- a/test/unit/CommandController.endpoints-test.js
+++ b/test/unit/CommandController.endpoints-test.js
@@ -8,6 +8,7 @@ chai.use(chaiHttp);
 const AudioFileHelper = require('../../command/AudioFileHelper');
 const polly_tts = require('../../command/polly_tts');
 const statusHelper = require('../../articlestatus/ArticleStatusHelper.js');
+const HostnameHelper = require('../../command/HostnameHelper.js');
 
 const expect = chai.expect;
 const fs = require('fs');
@@ -77,6 +78,14 @@ describe('CommandController - Endpoints', function() {
       });
 
     sinon.replace(
+      HostnameHelper.prototype,
+      'getHostnameData',
+      sinon.fake(function() {
+        console.log('Calling fake getHostnameData');
+        return { publisher_name: 'publisher', favicon_url: 'favicon' };
+      })
+    );
+    sinon.replace(
       db.prototype,
       'getAccessToken',
       sinon.fake(function() {
@@ -106,6 +115,28 @@ describe('CommandController - Endpoints', function() {
       'storeAudioFileLocation',
       sinon.fake(function() {
         console.log('Calling fake storeAudioFileLocation');
+      })
+    );
+    sinon.replace(
+      AudioFileHelper.prototype,
+      'checkFileExistence',
+      sinon.fake(function(url) {
+        console.log('Calling fake checkFileExistence');
+        return url == 'audio_file_url';
+      })
+    );
+    sinon.replace(
+      AudioFileHelper.prototype,
+      'getMetaAudioLocation',
+      sinon.fake(function() {
+        console.log('Calling fake getMetaAudioLocation');
+      })
+    );
+    sinon.replace(
+      AudioFileHelper.prototype,
+      'storeMetaAudioLocation',
+      sinon.fake(function() {
+        console.log('Calling fake storeMetaAudioLocation');
       })
     );
     sinon.replace(

--- a/test/unit/CommandController.endpoints-test.js
+++ b/test/unit/CommandController.endpoints-test.js
@@ -134,9 +134,16 @@ describe('CommandController - Endpoints', function() {
     );
     sinon.replace(
       AudioFileHelper.prototype,
-      'storeMetaAudioLocation',
+      'storeOutroLocation',
       sinon.fake(function() {
-        console.log('Calling fake storeMetaAudioLocation');
+        console.log('Calling fake storeOutroLocation');
+      })
+    );
+    sinon.replace(
+      AudioFileHelper.prototype,
+      'storeIntroLocation',
+      sinon.fake(function() {
+        console.log('Calling fake storeIntroLocation');
       })
     );
     sinon.replace(

--- a/test/unit/CommandController.endpoints-test.js
+++ b/test/unit/CommandController.endpoints-test.js
@@ -53,6 +53,7 @@ describe('CommandController - Endpoints', function() {
         return { action_results: [true], status: 1 };
       });
     nock('https://text.getpocket.com/v3')
+      .persist()
       .post('/text')
       .reply(function() {
         console.log('Fake Pocket API called on /text');
@@ -62,6 +63,7 @@ describe('CommandController - Endpoints', function() {
         ];
       });
     nock('https://api.smmry.com')
+      .persist()
       .get('/')
       .query(true)
       .reply(200, function(uri) {
@@ -312,6 +314,7 @@ describe('CommandController - Endpoints', function() {
     });
     after(function() {
       delete userData.url;
+      delete userData.meta_audio;
     });
     it('Returns data for article: firefox', done => {
       chai
@@ -335,6 +338,31 @@ describe('CommandController - Endpoints', function() {
           );
         });
     });
+
+    it('With meta_audio flag', done => {
+      userData.meta_audio = 1;
+      chai
+        .request(app)
+        .post('/command/article')
+        .set('x-access-token', 'token')
+        .send(userData)
+        .end((err, res) => {
+          console.log(res.body);
+          expect(res).have.status(200);
+          expect(res.body).be.a('object');
+          fs.readFile(
+            MOCK_DATA_PATH + '/ArticleMetaAudio_firefox.json',
+            'utf8',
+            function(err, data) {
+              if (err) {
+                return console.log(err);
+              }
+              expect(res.body).to.deep.equal(JSON.parse(data));
+              done();
+            }
+          );
+        });
+    });
   });
 
   describe('/summary', function() {
@@ -343,6 +371,7 @@ describe('CommandController - Endpoints', function() {
     });
     after(function() {
       delete userData.url;
+      delete userData.meta_audio;
     });
     it('Returns data for article: firefox', done => {
       chai
@@ -355,6 +384,30 @@ describe('CommandController - Endpoints', function() {
           expect(res.body).be.a('object');
           fs.readFile(
             MOCK_DATA_PATH + '/SearchAndPlayArticle_firefox.json',
+            'utf8',
+            function(err, data) {
+              if (err) {
+                return console.log(err);
+              }
+              expect(res.body).to.deep.equal(JSON.parse(data));
+              done();
+            }
+          );
+        });
+    });
+
+    it('With meta_audio flag', done => {
+      userData.meta_audio = 1;
+      chai
+        .request(app)
+        .post('/command/article')
+        .set('x-access-token', 'token')
+        .send(userData)
+        .end((err, res) => {
+          expect(res).have.status(200);
+          expect(res.body).be.a('object');
+          fs.readFile(
+            MOCK_DATA_PATH + '/ArticleMetaAudio_firefox.json',
             'utf8',
             function(err, data) {
               if (err) {

--- a/test/unit/data/ArticleMetaAudio_firefox.json
+++ b/test/unit/data/ArticleMetaAudio_firefox.json
@@ -7,8 +7,8 @@
   "author": "BRIAN X. CHEN",
   "lengthMinutes": 8,
   "length_minutes": 8,
-  "publisher": "nytimes.com",
-  "icon_url": "https://www.nytimes.com/favicon.ico",
+  "publisher": "publisher",
+  "icon_url": "favicon",
   "imageURL":
     "https://static01.nyt.com/images/2018/06/21/business/21Techfix/merlin_139815324_5d0f3563-0071-4a44-926f-3841b7e7fb44-facebookJumbo.jpg",
   "image_url":

--- a/test/unit/data/ArticleMetaAudio_firefox.json
+++ b/test/unit/data/ArticleMetaAudio_firefox.json
@@ -1,0 +1,21 @@
+{
+  "item_id": "2232154160",
+  "sort_id": 0,
+  "resolved_url":
+    "https://www.nytimes.com/2018/06/20/technology/personaltech/firefox-chrome-browser-privacy.html",
+  "title": "Firefox Is Back. It’s Time to Give It a Try.",
+  "author": "BRIAN X. CHEN",
+  "lengthMinutes": 8,
+  "length_minutes": 8,
+  "publisher": "nytimes.com",
+  "icon_url": "https://www.nytimes.com/favicon.ico",
+  "imageURL":
+    "https://static01.nyt.com/images/2018/06/21/business/21Techfix/merlin_139815324_5d0f3563-0071-4a44-926f-3841b7e7fb44-facebookJumbo.jpg",
+  "image_url":
+    "https://static01.nyt.com/images/2018/06/21/business/21Techfix/merlin_139815324_5d0f3563-0071-4a44-926f-3841b7e7fb44-facebookJumbo.jpg",
+  "url": "audio_file_url",
+  "instructions_url": "audio_file_url",
+  "intro_url": "audio_file_url",
+  "outro_url": "audio_file_url",
+  "offset_ms": 0
+}


### PR DESCRIPTION
Fixes #105 
Fixes #129 

Added `intro_url` and `outro_url` fields to /article and /summary endpoints when called with `meta_audio` flag set to 1.

`meta_audio` also replaces `end_instructions` flag from PR #98. So `instructions_url` field is now returned when called with `meta_audio` flag. Documentation is updated.

Added a test on /article and /summary with the `meta_audio` flag.

Set voice with `META_VOICE` env var
