### PR TITLE
Removed integ tests from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
   - "8.10"
-before_script: echo $TEST_API_URL && if [ $TRAVIS_PULL_REQUEST != "false" ]; then export TEST_API_URL="https://scout-stage-pr-$TRAVIS_PULL_REQUEST.herokuapp.com"; fi && echo $TEST_API_URL
-script: npm install && npm run lint && npm run travis-unit && if [ $TEST_API_ACCESS_TOKEN ]; then npm run integ-test; fi
+script: npm install && npm run lint && npm run travis-unit

--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ This can also be run on Heroku. Here are the instructions for running with Herok
 
 # Tests
 
-`npm test` runs the tests.
+`npm test` runs the tests (lint, unit tests, integration tests).
 
-For the integration tests, you need to add the `TEST_API_URL` and the `TEST_API_ACCESS_TOKEN` (JWT token) environment variables.
+To run lint individually: `npm run lint`.
+
+To run unit tests individually: `npm run unit-test`
+
+For the integration tests, you need to add the `TEST_API_URL` and the `TEST_API_ACCESS_TOKEN` (JWT token) environment variables. To run them: `npm run integ-test`.
+
+Travis runs automatically lint and unit-test. Integration tests need to be run manually.

--- a/test/integration/ScoutTitles.json
+++ b/test/integration/ScoutTitles.json
@@ -104,7 +104,7 @@
       "item_id": "1437596179",
       "sort_id": 7,
       "resolved_url":
-        "http://www.theverge.com/a/luka-artificial-intelligence-memorial-roman-mazurenko-bot",
+        "https://www.theverge.com/a/luka-artificial-intelligence-memorial-roman-mazurenko-bot",
       "title": "Speak, Memory",
       "author": "Casey Newton",
       "lengthMinutes": 30,


### PR DESCRIPTION
Fixes #132 

Removed Integration tests from Travis. Please run them locally `npm run integ-test`, don't forget to set env vars. Updated Readme
 
Seems also that Pocket API now returns https instead of the http url for the integration tests. I fixed it, I hope it doesn't switch back to http.

