### PR TITLE
Use is_article field

### DIFF
--- a/command/CommandController.js
+++ b/command/CommandController.js
@@ -579,13 +579,17 @@ async function searchForPocketArticle(getBody, searchTerm, extendedData) {
       logger.info('article count: ' + keysArr.length);
       if (keysArr.length > 0) {
         let isArticleId = 0;
+
+        // store the id for first object that is an article
         while (
           isArticleId < keysArr.length &&
           jsonBody.list[keysArr[isArticleId]].is_article != '1'
         ) {
           isArticleId++;
         }
+
         if (isArticleId < keysArr.length) {
+          // if we have a result
           result = await getArticleMetadata(
             jsonBody.list[keysArr[isArticleId]],
             extendedData

--- a/command/CommandController.js
+++ b/command/CommandController.js
@@ -304,20 +304,22 @@ async function scoutSummaries(userid, jsonBodyAttr, urlAttr, titleAttr, res) {
           let promiseArray = [];
           let arrJson = jsonBody[jsonBodyAttr];
           Object.keys(arrJson).forEach(key => {
-            summaryOptions.uri = summaryLink + arrJson[key][urlAttr];
-            logger.debug('Summary uri is: ' + summaryOptions.uri);
-            promiseArray.push(
-              rp(summaryOptions)
-                .then(sumResults => {
-                  let sumResultsJson = JSON.parse(sumResults);
-                  sumResultsJson['title'] = arrJson[key][titleAttr];
-                  return sumResultsJson;
-                })
-                .catch(function(err) {
-                  logger.error('Caught an error: ' + err);
-                  return JSON.stringify({});
-                })
-            );
+            if (arrJson[key].is_article == '1') {
+              summaryOptions.uri = summaryLink + arrJson[key][urlAttr];
+              logger.debug('Summary uri is: ' + summaryOptions.uri);
+              promiseArray.push(
+                rp(summaryOptions)
+                  .then(sumResults => {
+                    let sumResultsJson = JSON.parse(sumResults);
+                    sumResultsJson['title'] = arrJson[key][titleAttr];
+                    return sumResultsJson;
+                  })
+                  .catch(function(err) {
+                    logger.error('Caught an error: ' + err);
+                    return JSON.stringify({});
+                  })
+              );
+            }
           });
           logger.debug('RETURNING PROMISE.ALL ' + Date.now());
           return Promise.all(promiseArray);
@@ -388,7 +390,10 @@ async function getTitlesFromPocket(userid, extendedData) {
 
       // process list of articles
       Object.keys(jsonBody.list).forEach(key => {
-        if (jsonBody.list[key].resolved_title) {
+        if (
+          jsonBody.list[key].resolved_title &&
+          jsonBody.list[key].is_article == '1'
+        ) {
           articlesPromises.push(
             getArticleMetadata(jsonBody.list[key], extendedData)
           );
@@ -530,10 +535,23 @@ async function searchForPocketArticle(getBody, searchTerm, extendedData) {
       logger.debug('keysarr = ' + keysArr);
       logger.info('article count: ' + keysArr.length);
       if (keysArr.length > 0) {
-        result = await getArticleMetadata(
-          jsonBody.list[keysArr[0]],
-          extendedData
-        );
+        let isArticleId = 0;
+        while (
+          isArticleId < keysArr.length &&
+          jsonBody.list[keysArr[isArticleId]].is_article != '1'
+        ) {
+          isArticleId++;
+        }
+        if (isArticleId < keysArr.length) {
+          result = await getArticleMetadata(
+            jsonBody.list[keysArr[isArticleId]],
+            extendedData
+          );
+        } else {
+          logger.warn(
+            `Searching for '${searchTerm}' failed to find a matching article.`
+          );
+        }
       }
     } else {
       logger.warn(
@@ -678,10 +696,10 @@ function findBestScoringTitle(searchPhrase, articleMetadataArray) {
       if (iCount >= articleMetadataArray.length) {
         logger.debug('Done getting results.');
         logger.debug('Max Score is: ' + maxValue);
-        logger.info('Article is: ' + articleMetadataArray[curMaxIndex].title);
         if (maxValue === 0) {
           reject('NoMatchFound');
         }
+        logger.info('Article is: ' + articleMetadataArray[curMaxIndex].title);
         resolve(articleMetadataArray[curMaxIndex]);
       }
     });

--- a/command/CommandController.js
+++ b/command/CommandController.js
@@ -273,7 +273,7 @@ async function processArticleRequest(
   metaAudioRequested
 ) {
   const getBody = await buildPocketRequestBody(req.body.userid);
-  let result = await searchForPocketArticle(
+  let result = await searchForPocketArticleByUrl(
     getBody,
     req.body.url,
     extendedData || metaAudioRequested
@@ -289,7 +289,7 @@ async function processArticleRequest(
       summaryOnly
     );
   } else {
-    logger.info('error:  no result returned from searchForPocketArticle');
+    logger.info('error:  no result returned from searchForPocketArticleByUrl');
   }
 
   // if we didn't find it in the DB, create the audio file
@@ -652,14 +652,14 @@ async function archiveTitle(userId, itemId, res) {
 }
 
 /**
- * Looks for an article in user's account that matches the searchTerm,
+ * Looks for an article in user's account that matches the url,
  * and if found, returns metadata for it. Otherwise undefined.
  */
-async function searchForPocketArticle(getBody, searchTerm, extendedData) {
+async function searchForPocketArticleByUrl(getBody, url, extendedData) {
   let result;
-  if (searchTerm) {
-    logger.info('Search term is: ' + searchTerm);
-    getBody.search = searchTerm;
+  if (url) {
+    logger.info('Search for article matching url: ' + url);
+    getBody.search = url;
     getOptions.body = JSON.stringify(getBody);
     const body = await rp(getOptions);
     const jsonBody = JSON.parse(body);
@@ -686,14 +686,12 @@ async function searchForPocketArticle(getBody, searchTerm, extendedData) {
           );
         } else {
           logger.warn(
-            `Searching for '${searchTerm}' failed to find a matching article.`
+            `Searching for '${url}' failed to find a matching article.`
           );
         }
       }
     } else {
-      logger.warn(
-        `Searching for '${searchTerm}' failed to find a matching article.`
-      );
+      logger.warn(`Searching for '${url}' failed to find a matching article.`);
     }
   }
   return result;

--- a/test/unit/data/ScoutTitles.json
+++ b/test/unit/data/ScoutTitles.json
@@ -15,21 +15,6 @@
         "https://static01.nyt.com/images/2018/06/21/business/21Techfix/merlin_139815324_5d0f3563-0071-4a44-926f-3841b7e7fb44-facebookJumbo.jpg"
     },
     {
-      "item_id": "2229373616",
-      "sort_id": 1,
-      "resolved_url":
-        "https://medium.com/s/trustissues/blockchain-disciples-have-a-new-goal-running-our-next-election-2bfe4dff3c7",
-      "title":
-        "Blockchain Disciples Have a New Goal: Running Our Next Election",
-      "author": "Aaron Gell",
-      "lengthMinutes": 0,
-      "length_minutes": 0,
-      "imageURL":
-        "https://cdn-images-1.medium.com/max/1200/1*1eyW1vZGvrlArd8pULCdwA.jpeg",
-      "image_url":
-        "https://cdn-images-1.medium.com/max/1200/1*1eyW1vZGvrlArd8pULCdwA.jpeg"
-    },
-    {
       "item_id": "2232356671",
       "sort_id": 2,
       "resolved_url":

--- a/test/unit/data/getTitles.json
+++ b/test/unit/data/getTitles.json
@@ -16,21 +16,6 @@
         "https://static01.nyt.com/images/2018/06/21/business/21Techfix/merlin_139815324_5d0f3563-0071-4a44-926f-3841b7e7fb44-facebookJumbo.jpg"
     },
     {
-      "item_id": "2229373616",
-      "sort_id": 1,
-      "resolved_url":
-        "https://medium.com/s/trustissues/blockchain-disciples-have-a-new-goal-running-our-next-election-2bfe4dff3c7",
-      "title":
-        "Blockchain Disciples Have a New Goal: Running Our Next Election",
-      "author": "Aaron Gell",
-      "lengthMinutes": 0,
-      "length_minutes": 0,
-      "imageURL":
-        "https://cdn-images-1.medium.com/max/1200/1*1eyW1vZGvrlArd8pULCdwA.jpeg",
-      "image_url":
-        "https://cdn-images-1.medium.com/max/1200/1*1eyW1vZGvrlArd8pULCdwA.jpeg"
-    },
-    {
       "item_id": "2232356671",
       "sort_id": 2,
       "resolved_url":


### PR DESCRIPTION
Fixes #134 

nb: it seems like Pocket returns is_article with value 0 for some articles (e.g. Blockchain article that was in the unit tests) and value 1 for some things that are not articles (e.g. Github pull request)

Todo: update unit tests for that and test searchForPocketArticle() by calling /article and /summary endpoints 