### PR TITLE
Fix RangeError when article.lang value is missing

### DIFF
--- a/command/CommandController.js
+++ b/command/CommandController.js
@@ -207,7 +207,6 @@ router.post('/articleservice', VerifyToken, async function(req, res) {
           buildIntro(article),
           voice
         );
-
         let audioMetadata = await buildPocketAudio(introFile, articleFile);
         // Add the correct voice:
         audioMetadata['voice'] = voice;
@@ -824,8 +823,7 @@ function buildIntro(article) {
   //Intro: “article title, published by host, on publish date"
   let introFullText;
   let dateOptions = { year: 'numeric', month: 'long', day: 'numeric' };
-  const articleLang = article.lang ? article.lang : 'en';
-  if (articleLang === 'en') {
+  if (!article.lang || article.lang === 'en') {
     if (article.timePublished) {
       let publishedDate = new Date(article.timePublished * 1000);
       let dateString = publishedDate.toLocaleDateString('en-US', dateOptions);

--- a/command/CommandController.js
+++ b/command/CommandController.js
@@ -198,19 +198,16 @@ router.post('/articleservice', VerifyToken, async function(req, res) {
       if (article) {
         // Build the stitched file first
         let voice = vc.findVoice(article.lang);
-        logger.debug(`** creating article file`);
         let articleFile = await createAudioFileFromText(
           `${article.article}`,
           voice
         );
 
-        logger.debug(`** creating intro file`);
         let introFile = await createAudioFileFromText(
           buildIntro(article),
           voice
         );
 
-        logger.debug(`** creating pocket file`);
         let audioMetadata = await buildPocketAudio(introFile, articleFile);
         // Add the correct voice:
         audioMetadata['voice'] = voice;
@@ -860,7 +857,6 @@ function buildIntro(article) {
         : `${article.title}.`;
     }
   }
-  logger.debug('** leaving buildIntro');
   return introFullText;
 }
 

--- a/command/CommandController.js
+++ b/command/CommandController.js
@@ -198,15 +198,19 @@ router.post('/articleservice', VerifyToken, async function(req, res) {
       if (article) {
         // Build the stitched file first
         let voice = vc.findVoice(article.lang);
+        logger.debug(`** creating article file`);
         let articleFile = await createAudioFileFromText(
           `${article.article}`,
           voice
         );
 
+        logger.debug(`** creating intro file`);
         let introFile = await createAudioFileFromText(
           buildIntro(article),
           voice
         );
+
+        logger.debug(`** creating pocket file`);
         let audioMetadata = await buildPocketAudio(introFile, articleFile);
         // Add the correct voice:
         audioMetadata['voice'] = voice;

--- a/command/CommandController.js
+++ b/command/CommandController.js
@@ -827,7 +827,8 @@ function buildIntro(article) {
   //Intro: “article title, published by host, on publish date"
   let introFullText;
   let dateOptions = { year: 'numeric', month: 'long', day: 'numeric' };
-  if (article.lang == 'en') {
+  const articleLang = article.lang ? article.lang : 'en';
+  if (articleLang === 'en') {
     if (article.timePublished) {
       let publishedDate = new Date(article.timePublished * 1000);
       let dateString = publishedDate.toLocaleDateString('en-US', dateOptions);
@@ -859,6 +860,7 @@ function buildIntro(article) {
         : `${article.title}.`;
     }
   }
+  logger.debug('** leaving buildIntro');
   return introFullText;
 }
 

--- a/data/database.js
+++ b/data/database.js
@@ -87,7 +87,7 @@ class Database {
       item_id: articleId,
       uuid: uuidgen.generate(),
       lang,
-      voice: voice,
+      voice,
       codec: 'mp3',
       bitrate: 40000,
       samplerate: 16000,
@@ -102,7 +102,7 @@ class Database {
       item_id: articleId,
       uuid: uuidgen.generate(),
       lang,
-      voice: voice,
+      voice,
       codec: 'opus',
       bitrate: 24000,
       samplerate: 48000,
@@ -115,11 +115,7 @@ class Database {
   }
 
   async storeMobileLocation(articleId, lang = 'en', voice, audioMetadata) {
-    logger.info(
-      `storeMobileLocation for ${articleId}: ${
-        audioMetadata.url
-      } and lang: ${lang}`
-    );
+    logger.info(`storeMobileLocation for ${articleId}: ${audioMetadata.url}`);
     let mp3 = new AudioFiles({
       item_id: articleId,
       uuid: uuidgen.generate(),

--- a/data/database.js
+++ b/data/database.js
@@ -117,7 +117,7 @@ class Database {
     let mp3 = new AudioFiles({
       item_id: articleId,
       uuid: uuidgen.generate(),
-      lang: audioMetadata.lang,
+      lang: lang ? lang : 'en',
       voice: voice,
       codec: 'mp3',
       bitrate: 40000,
@@ -134,7 +134,7 @@ class Database {
     let opus = new AudioFiles({
       item_id: articleId,
       uuid: uuidgen.generate(),
-      lang: audioMetadata.lang,
+      lang: lang ? lang : 'en',
       voice: voice,
       codec: 'opus',
       bitrate: 24000,

--- a/data/database.js
+++ b/data/database.js
@@ -117,7 +117,7 @@ class Database {
     let mp3 = new AudioFiles({
       item_id: articleId,
       uuid: uuidgen.generate(),
-      lang: lang ? lang : 'en',
+      lang: 'lang',
       voice: voice,
       codec: 'mp3',
       bitrate: 40000,
@@ -134,7 +134,7 @@ class Database {
     let opus = new AudioFiles({
       item_id: articleId,
       uuid: uuidgen.generate(),
-      lang: lang ? lang : 'en',
+      lang: 'lang',
       voice: voice,
       codec: 'opus',
       bitrate: 24000,

--- a/data/database.js
+++ b/data/database.js
@@ -81,11 +81,12 @@ class Database {
     });
   }
 
-  async storeAudioFileLocation(articleId, type, voice, location) {
+  async storeAudioFileLocation(articleId, type, voice, location, lang = 'en') {
     logger.info(`storeAudioFileLocation for ${articleId}/${type}: ${location}`);
     let mp3 = new AudioFiles({
       item_id: articleId,
       uuid: uuidgen.generate(),
+      lang,
       voice: voice,
       codec: 'mp3',
       bitrate: 40000,
@@ -100,6 +101,7 @@ class Database {
     let opus = new AudioFiles({
       item_id: articleId,
       uuid: uuidgen.generate(),
+      lang,
       voice: voice,
       codec: 'opus',
       bitrate: 24000,
@@ -112,13 +114,17 @@ class Database {
     logger.debug('after opus save');
   }
 
-  async storeMobileLocation(articleId, lang, voice, audioMetadata) {
-    logger.info(`storeMobileLocation for ${articleId}: ${audioMetadata.url}`);
+  async storeMobileLocation(articleId, lang = 'en', voice, audioMetadata) {
+    logger.info(
+      `storeMobileLocation for ${articleId}: ${
+        audioMetadata.url
+      } and lang: ${lang}`
+    );
     let mp3 = new AudioFiles({
       item_id: articleId,
       uuid: uuidgen.generate(),
-      lang: 'lang',
-      voice: voice,
+      lang,
+      voice,
       codec: 'mp3',
       bitrate: 40000,
       duration: audioMetadata.duration,
@@ -134,8 +140,8 @@ class Database {
     let opus = new AudioFiles({
       item_id: articleId,
       uuid: uuidgen.generate(),
-      lang: 'lang',
-      voice: voice,
+      lang,
+      voice,
       codec: 'opus',
       bitrate: 24000,
       duration: audioMetadata.duration,


### PR DESCRIPTION
Fixes #165 

When missing the language, just assume that it's "en" since we are already defaulting to a US English voice for the TTS. 

Error was coming from this block in buildIntro() when article.lang is undefined:
![image](https://user-images.githubusercontent.com/2423092/45519249-1cf3f800-b769-11e8-8b98-c4c4a23092b4.png)

I protected that instance and then added default lang value of 'en' to a couple of the store functions in the database.
