### PR TITLE
skip xcode when no SQS

### DIFF
--- a/command/CommandController.js
+++ b/command/CommandController.js
@@ -218,10 +218,18 @@ router.post('/articleservice', VerifyToken, async function(req, res) {
           voice,
           audioMetadata
         );
-        logger.debug('Before buildPocketResponse');
-        let response = buildPocketResponse(audioMetadata, version);
+
+        // Now retry the metadata call
+        mobileMetadata = await audioHelper.getMobileFileMetadata(
+          req.body.article_id
+        );
+        let response = await buildPocketResponseFromMetadata(
+          mobileMetadata,
+          version
+        );
+
+        // let response = buildPocketResponse(audioMetadata, version);
         // Send it back to the mobile as quick as possible.
-        logger.info('POST article resp: ' + JSON.stringify(response));
         res.status(200).send(JSON.stringify(response));
 
         // Upload the individual parts for use by Alexa later & cleanup.

--- a/command/CommandController.js
+++ b/command/CommandController.js
@@ -252,23 +252,19 @@ router.post('/articleservice', VerifyToken, async function(req, res) {
           );
         } else {
           logger.error('No language found for article:' + req.body.article_id);
-          res
-            .status(404)
-            .send(
-              JSON.stringify({
-                speech: `There was an error processing the article. No language`
-              })
-            );
+          res.status(404).send(
+            JSON.stringify({
+              speech: `There was an error processing the article. No language`
+            })
+          );
         }
       } else {
         logger.error('Not an article: ' + req.body.article_id);
-        res
-          .status(404)
-          .send(
-            JSON.stringify({
-              speech: `There was an error processing the article. Not an article`
-            })
-          );
+        res.status(404).send(
+          JSON.stringify({
+            speech: `There was an error processing the article. Not an article`
+          })
+        );
       }
     }
   } catch (reason) {

--- a/command/CommandController.js
+++ b/command/CommandController.js
@@ -223,6 +223,7 @@ router.post('/articleservice', VerifyToken, async function(req, res) {
         mobileMetadata = await audioHelper.getMobileFileMetadata(
           req.body.article_id
         );
+        logger.info(`MMD is`, mobileMetadata);
         let response = await buildPocketResponseFromMetadata(
           mobileMetadata,
           version

--- a/command/xcodeQueue.js
+++ b/command/xcodeQueue.js
@@ -18,8 +18,12 @@ AWS.config.update({ region: process.env.AWS_REGION });
 var sqs = new AWS.SQS({ apiVersion: '2012-11-05' });
 
 const xcodeQueue = {
+  useXcode: function() {
+    return !!process.env.SQS_QUEUE;
+  },
+
   add: function(file) {
-    if (process.env.SQS_QUEUE) {
+    if (this.useXcode()) {
       logger.debug('XCODE: filename: ' + file);
       var jsonBody = {
         filename: file,

--- a/command/xcodeQueue.js
+++ b/command/xcodeQueue.js
@@ -19,27 +19,31 @@ var sqs = new AWS.SQS({ apiVersion: '2012-11-05' });
 
 const xcodeQueue = {
   add: function(file) {
-    logger.debug('XCODE: filename: ' + file);
-    var jsonBody = {
-      filename: file,
-      targetCodec: 'opus 24'
-    };
+    if (process.env.SQS_QUEUE) {
+      logger.debug('XCODE: filename: ' + file);
+      var jsonBody = {
+        filename: file,
+        targetCodec: 'opus 24'
+      };
 
-    var params = {
-      MessageAttributes: {},
-      MessageGroupId: 'scout',
-      MessageDeduplicationId: uuidgen.generate(),
-      MessageBody: JSON.stringify(jsonBody),
-      QueueUrl: process.env.SQS_QUEUE
-    };
+      var params = {
+        MessageAttributes: {},
+        MessageGroupId: 'scout',
+        MessageDeduplicationId: uuidgen.generate(),
+        MessageBody: JSON.stringify(jsonBody),
+        QueueUrl: process.env.SQS_QUEUE
+      };
 
-    sqs.sendMessage(params, function(err, data) {
-      if (err) {
-        console.log('Error', err);
-      } else {
-        console.log('Success', data.MessageId);
-      }
-    });
+      sqs.sendMessage(params, function(err, data) {
+        if (err) {
+          logger.error('Error', err);
+        } else {
+          logger.debug('Success', data.MessageId);
+        }
+      });
+    } else {
+      logger.debug('No SQS queue defined, skipping XCode message.');
+    }
   }
 };
 

--- a/data/database.js
+++ b/data/database.js
@@ -227,7 +227,7 @@ class Database {
         const opusAudioFile = new AudioFiles(opusFileInfo);
         promiseArr.push(opusAudioFile.save());
       }
-      await Promise.all([promiseArr]);
+      await Promise.all(promiseArr);
     } catch (err) {
       logger.error(`storeAudioFileLocation error: ${err}`);
     }

--- a/data/database.js
+++ b/data/database.js
@@ -4,7 +4,7 @@ const Hostname = require('./models/Hostname');
 const logger = require('../logger');
 const uuidgen = require('node-uuid-generator');
 const constants = require('../constants');
-const xcodeQueue = require('./xcodeQueue');
+const xcodeQueue = require('../command/xcodeQueue');
 
 class Database {
   async processScoutUser(userid, access_token) {

--- a/test/unit/CommandController.endpoints-test.js
+++ b/test/unit/CommandController.endpoints-test.js
@@ -598,7 +598,7 @@ describe('CommandController - Endpoints', function() {
       delete userData.article_id;
     });
 
-    it('should return metadata for the article', done => {
+    it.only('should return metadata for the article', done => {
       chai
         .request(app)
         .post('/command/articleservice')

--- a/test/unit/CommandController.endpoints-test.js
+++ b/test/unit/CommandController.endpoints-test.js
@@ -200,6 +200,14 @@ describe('CommandController - Endpoints', function() {
     );
     sinon.replace(
       polly_tts,
+      'getFileSizeFromUrl',
+      sinon.fake(function() {
+        console.log('Calling fake getFileSizeFromUrl');
+        return 999;
+      })
+    );
+    sinon.replace(
+      polly_tts,
       'processPocketAudio',
       sinon.fake(function() {
         console.log('Calling fake processPocketAudio');

--- a/test/unit/CommandController.endpoints-test.js
+++ b/test/unit/CommandController.endpoints-test.js
@@ -606,7 +606,7 @@ describe('CommandController - Endpoints', function() {
       delete userData.article_id;
     });
 
-    it.only('should return metadata for the article', done => {
+    it('should return metadata for the article', done => {
       chai
         .request(app)
         .post('/command/articleservice')

--- a/test/unit/CommandController.endpoints-test.js
+++ b/test/unit/CommandController.endpoints-test.js
@@ -82,7 +82,10 @@ describe('CommandController - Endpoints', function() {
       'getHostnameData',
       sinon.fake(function() {
         console.log('Calling fake getHostnameData');
-        return { publisher_name: 'publisher', favicon_url: 'favicon' };
+        return {
+          publisher_name: 'publisher',
+          favicon_url: 'http://favicon.url'
+        };
       })
     );
     sinon.replace(
@@ -122,7 +125,7 @@ describe('CommandController - Endpoints', function() {
       'checkFileExistence',
       sinon.fake(function(url) {
         console.log('Calling fake checkFileExistence');
-        return url == 'audio_file_url';
+        return url == 'http://audio_file.mp3';
       })
     );
     sinon.replace(
@@ -130,10 +133,12 @@ describe('CommandController - Endpoints', function() {
       'getMobileFileMetadata',
       sinon.fake(function() {
         console.log('Calling fake getMobileFileMetadata');
-        return {
-          fileUrl: 'audio_file_url',
-          duration: 300
-        };
+        return [
+          {
+            url: 'http://audio_file.mp3',
+            duration: 300
+          }
+        ];
       })
     );
     sinon.replace(
@@ -142,8 +147,8 @@ describe('CommandController - Endpoints', function() {
       sinon.fake(function() {
         console.log('Calling fake getMetaAudioLocation');
         return {
-          intro: 'audio_file_url',
-          outro: 'audio_file_url'
+          intro: 'http://audio_file.mp3',
+          outro: 'http://audio_file.mp3'
         };
       })
     );
@@ -182,7 +187,7 @@ describe('CommandController - Endpoints', function() {
       'getSpeechSynthUrl',
       sinon.fake(function() {
         console.log('Calling fake getSpeechSynthUrl');
-        return 'audio_file_url';
+        return 'http://audio_file.mp3';
       })
     );
     sinon.replace(
@@ -190,7 +195,7 @@ describe('CommandController - Endpoints', function() {
       'synthesizeSpeechFile',
       sinon.fake(function() {
         console.log('Calling fake synthesizeSpeechFile');
-        return 'audio_file_url';
+        return 'http://audio_file.mp3';
       })
     );
     sinon.replace(
@@ -200,7 +205,7 @@ describe('CommandController - Endpoints', function() {
         console.log('Calling fake processPocketAudio');
         return {
           format: 'mp3',
-          url: 'audio_url',
+          url: 'http://audio_file.mp3',
           status: 'available',
           voice: 'Joanna',
           sample_rate: '48000',
@@ -214,7 +219,7 @@ describe('CommandController - Endpoints', function() {
       'uploadFile',
       sinon.fake(function() {
         console.log('Calling fake uploadFile');
-        return 'audio_file_url';
+        return 'http://audio_file.mp3';
       })
     );
     sinon.replace(
@@ -222,7 +227,7 @@ describe('CommandController - Endpoints', function() {
       'postProcessPart',
       sinon.fake(function() {
         console.log('Calling fake uploadFile');
-        return 'audio_file_url';
+        return 'http://audio_file.mp3';
       })
     );
   });
@@ -403,7 +408,7 @@ describe('CommandController - Endpoints', function() {
           .end((err, res) => {
             expect(res).have.status(200);
             expect(res.body).be.a('object');
-            expect(res.body.url).be.equal('audio_file_url');
+            expect(res.body.url).be.equal('http://audio_file.mp3');
             done();
           });
       });

--- a/test/unit/data/ArticleMetaAudio_firefox.json
+++ b/test/unit/data/ArticleMetaAudio_firefox.json
@@ -1,21 +1,18 @@
 {
   "item_id": "2232154160",
   "sort_id": 0,
-  "resolved_url":
-    "https://www.nytimes.com/2018/06/20/technology/personaltech/firefox-chrome-browser-privacy.html",
+  "resolved_url": "https://www.nytimes.com/2018/06/20/technology/personaltech/firefox-chrome-browser-privacy.html",
   "title": "Firefox Is Back. It’s Time to Give It a Try.",
   "author": "BRIAN X. CHEN",
   "lengthMinutes": 8,
   "length_minutes": 8,
   "publisher": "publisher",
-  "icon_url": "favicon",
-  "imageURL":
-    "https://static01.nyt.com/images/2018/06/21/business/21Techfix/merlin_139815324_5d0f3563-0071-4a44-926f-3841b7e7fb44-facebookJumbo.jpg",
-  "image_url":
-    "https://static01.nyt.com/images/2018/06/21/business/21Techfix/merlin_139815324_5d0f3563-0071-4a44-926f-3841b7e7fb44-facebookJumbo.jpg",
-  "url": "audio_file_url",
-  "instructions_url": "audio_file_url",
-  "intro_url": "audio_file_url",
-  "outro_url": "audio_file_url",
+  "icon_url": "http://favicon.url",
+  "imageURL": "https://static01.nyt.com/images/2018/06/21/business/21Techfix/merlin_139815324_5d0f3563-0071-4a44-926f-3841b7e7fb44-facebookJumbo.jpg",
+  "image_url": "https://static01.nyt.com/images/2018/06/21/business/21Techfix/merlin_139815324_5d0f3563-0071-4a44-926f-3841b7e7fb44-facebookJumbo.jpg",
+  "url": "http://audio_file.mp3",
+  "instructions_url": "http://audio_file.mp3",
+  "intro_url": "http://audio_file.mp3",
+  "outro_url": "http://audio_file.mp3",
   "offset_ms": 0
 }

--- a/test/unit/data/SearchAndPlayArticle_firefox.json
+++ b/test/unit/data/SearchAndPlayArticle_firefox.json
@@ -1,16 +1,13 @@
 {
   "item_id": "2232154160",
   "sort_id": 0,
-  "resolved_url":
-    "https://www.nytimes.com/2018/06/20/technology/personaltech/firefox-chrome-browser-privacy.html",
+  "resolved_url": "https://www.nytimes.com/2018/06/20/technology/personaltech/firefox-chrome-browser-privacy.html",
   "title": "Firefox Is Back. It’s Time to Give It a Try.",
   "author": "BRIAN X. CHEN",
   "lengthMinutes": 8,
   "length_minutes": 8,
   "offset_ms": 0,
-  "imageURL":
-    "https://static01.nyt.com/images/2018/06/21/business/21Techfix/merlin_139815324_5d0f3563-0071-4a44-926f-3841b7e7fb44-facebookJumbo.jpg",
-  "image_url":
-    "https://static01.nyt.com/images/2018/06/21/business/21Techfix/merlin_139815324_5d0f3563-0071-4a44-926f-3841b7e7fb44-facebookJumbo.jpg",
-  "url": "audio_file_url"
+  "imageURL": "https://static01.nyt.com/images/2018/06/21/business/21Techfix/merlin_139815324_5d0f3563-0071-4a44-926f-3841b7e7fb44-facebookJumbo.jpg",
+  "image_url": "https://static01.nyt.com/images/2018/06/21/business/21Techfix/merlin_139815324_5d0f3563-0071-4a44-926f-3841b7e7fb44-facebookJumbo.jpg",
+  "url": "http://audio_file.mp3"
 }

--- a/test/unit/data/articleservice.json
+++ b/test/unit/data/articleservice.json
@@ -1,3 +1,3 @@
 {
-  "url": "audio_file_url"
+  "url": "http://audio_file.mp3"
 }


### PR DESCRIPTION
Fixes #178 

If there is not an SQS queue address defined in `process.env.SQS_QUEUE`, then no attempt will be made to send a message to the scout-xcode process requesting Opus encoding for audio files. Additionally, no prospective .opus records will be created in the AudioFiles DB and calls to /articleservice will not return info about .opus files. 

* Added xcodeQueue.useXcode() function to determine if we should be sending XCode/opus requests
* Did some refactoring on the /articleservice API
  * removed `buildPocketResponse()` in favor of using `getMobileFileMetadata()` to retrieve true records from AudioFiles DB
  * refactored the error conditions a bit
* Modified some sample test data. A couple of the support functions expect the audio URLs to contain '/' and '.mp3', so changed all dummy URLs to "http://audio_file.mp3"