### PR TITLE
/article endpoint should generate the same intro format as /articleservice

### DIFF
--- a/command/CommandController.js
+++ b/command/CommandController.js
@@ -371,7 +371,7 @@ async function processArticleRequest(
     if (summaryOnly) {
       audioUrl = await buildSummaryAudioFromUrl(req.body.url);
     } else {
-      let article = await getPocketArticleTextFromUrl(url);
+      let article = await getPocketArticleTextFromUrl(req.body.url);
       audioUrl = await buildAudioFromText(`${article.article}`);
     }
 
@@ -857,36 +857,46 @@ async function buildAudioFromUrl(url) {
   return buildAudioFromText(`${article.article}`);
 }
 
-async function buildIntro(articleUrl, title, lang, timePublished) {
+async function buildIntro(
+  articleUrl,
+  articleTitle,
+  articleLang,
+  timePublished
+) {
   //Intro: “article title, published by host, on publish date"
   let introFullText;
   let dateOptions = { year: 'numeric', month: 'long', day: 'numeric' };
   let publisher = await hostnameHelper.getHostnameData(articleUrl, 'publisher');
-  if (!lang || lang === 'en') {
+  if (!articleLang || articleLang === 'en') {
     if (timePublished) {
       let publishedDate = new Date(timePublished * 1000);
       let dateString = publishedDate.toLocaleDateString('en-US', dateOptions);
 
       introFullText = publisher
-        ? `${title}, published by ${publisher}, on ${dateString}`
-        : `${title}, published on ${dateString}`;
+        ? `${articleTitle}, published by ${publisher}, on ${dateString}`
+        : `${articleTitle}, published on ${dateString}`;
     } else {
       // The case where date is not available.
       introFullText = publisher
-        ? `${title}, published by ${publisher}.`
-        : `${title}.`;
+        ? `${articleTitle}, published by ${publisher}.`
+        : `${articleTitle}.`;
     }
   } else {
     if (timePublished) {
       let publishedDate = new Date(timePublished * 1000);
-      let dateString = publishedDate.toLocaleDateString(lang, dateOptions);
+      let dateString = publishedDate.toLocaleDateString(
+        articleLang,
+        dateOptions
+      );
 
       introFullText = publisher
-        ? `${title}, ${publisher}, ${dateString}`
-        : `${title}, ${dateString}`;
+        ? `${articleTitle}, ${publisher}, ${dateString}`
+        : `${articleTitle}, ${dateString}`;
     } else {
       // The case where date is not available.
-      introFullText = publisher ? `${title}, ${publisher}.` : `${title}.`;
+      introFullText = publisher
+        ? `${articleTitle}, ${publisher}.`
+        : `${articleTitle}.`;
     }
   }
   return introFullText;

--- a/command/CommandController.js
+++ b/command/CommandController.js
@@ -371,8 +371,7 @@ async function processArticleRequest(
     if (summaryOnly) {
       audioUrl = await buildSummaryAudioFromUrl(req.body.url);
     } else {
-      let article = await getPocketArticleTextFromUrl(req.body.url);
-      audioUrl = await buildAudioFromText(`${article.article}`);
+      audioUrl = await buildAudioFromUrl(req.body.url);
     }
 
     if (result) {
@@ -453,8 +452,6 @@ async function generateMetaAudio(data, summaryOnly) {
       );
     } else {
       // It's a full article
-      console.log('** generateMetaAudio data param:');
-      console.log(data);
       let introFullText = await buildIntro(
         articleTextDetails.resolvedUrl,
         articleTextDetails.title,
@@ -925,7 +922,6 @@ async function getPocketArticleTextFromUrl(url) {
   logger.info('Getting article from pocket API: ' + url);
   const article = JSON.parse(await rp(articleOptions));
   logger.info('Returned article from pocket API: ' + article.title);
-  console.log(article);
   return article;
 }
 

--- a/command/CommandController.js
+++ b/command/CommandController.js
@@ -208,7 +208,12 @@ router.post('/articleservice', VerifyToken, async function(req, res) {
           );
 
           let introFile = await createAudioFileFromText(
-            await buildIntro(article),
+            await buildIntro(
+              article.resolvedUrl,
+              article.title,
+              article.lang,
+              article.timePublished
+            ),
             voice.meta
           );
           let audioMetadata = await buildPocketAudio(introFile, articleFile);
@@ -852,14 +857,11 @@ async function buildAudioFromUrl(url) {
   return buildAudioFromText(`${article.article}`);
 }
 
-async function buildIntro({ resolvedUrl, title, lang, timePublished }) {
+async function buildIntro(articleUrl, title, lang, timePublished) {
   //Intro: “article title, published by host, on publish date"
   let introFullText;
   let dateOptions = { year: 'numeric', month: 'long', day: 'numeric' };
-  let publisher = await hostnameHelper.getHostnameData(
-    resolvedUrl,
-    'publisher'
-  );
+  let publisher = await hostnameHelper.getHostnameData(articleUrl, 'publisher');
   if (!lang || lang === 'en') {
     if (timePublished) {
       let publishedDate = new Date(timePublished * 1000);


### PR DESCRIPTION
The desired intro format for both endpoints is:
<Title> published by <Publisher> on <Date>

* Change signature of buildIntro() to enumerate specific parameters 
* In generateMetaAudio(), which is used by the `/article` endpoint, make a call to buildIntro to get the proper string. 
  * To generate the outro, were already making a call to the Pocket /text API which has all the info we need to build the intro too, so I moved this up higher in the function so we could use it for both intro and outro.